### PR TITLE
feat(auth/gateway): implement JWT authentication and authorisation flow

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -45,28 +45,53 @@
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
 
-<!--        &lt;!&ndash; Security dependencies &ndash;&gt;-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-starter-security</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-starter-oauth2-client</artifactId>-->
-<!--        </dependency>-->
+        <!-- Security dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
+        <!-- JJWT Library (token generation/parsing) -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter-data-mongodb</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>me.paulschwarz</groupId>
@@ -92,6 +117,21 @@
             <version>3.0.5</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-api</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
         <!-- Shared Libraries -->
         <dependency>
             <groupId>gtp</groupId>
@@ -101,6 +141,11 @@
         <dependency>
             <groupId>gtp</groupId>
             <artifactId>common-security</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>gtp</groupId>
+            <artifactId>common-audit</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/auth-service/src/main/java/gtp/bytebites/AuthService.java
+++ b/auth-service/src/main/java/gtp/bytebites/AuthService.java
@@ -3,6 +3,7 @@ package gtp.bytebites;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
 @EnableDiscoveryClient

--- a/auth-service/src/main/java/gtp/bytebites/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/controller/AuthController.java
@@ -1,0 +1,177 @@
+package gtp.bytebites.auth.controller;
+
+import gtp.bytebites.auth.dto.request.LoginRequest;
+import gtp.bytebites.auth.dto.request.RegisterRequest;
+import gtp.bytebites.auth.dto.response.ApiResponse;
+import gtp.bytebites.auth.dto.response.ErrorResponse;
+import gtp.bytebites.auth.dto.response.JwtResponse;
+import gtp.bytebites.auth.exception.EmailExistException;
+import gtp.bytebites.auth.service.AuthService;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Valid;
+import jakarta.validation.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Authentication controller handling user registration, login, logout, and token operations.
+ * <p>
+ * Provides REST endpoints for core authentication workflows including:
+ * <ul>
+ *   <li>User registration and validation</li>
+ *   <li>JWT-based authentication</li>
+ *   <li>OAuth2 integration endpoints</li>
+ *   <li>Token management</li>
+ *   <li>Authorization checks</li>
+ * </ul>
+ * </p>
+ *
+ * @see AuthService
+ * @see JwtResponse
+ * @see org.springframework.security.authentication
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+@CrossOrigin(origins = "*", maxAge = 3600)
+public class AuthController {
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final AuthService authService;
+    private final Validator validator;
+
+    /**
+     * Constructs an AuthController with required dependencies.
+     *
+     * @param authService the authentication service for business logic
+     * @param validator the validator for request validation
+     */
+    public AuthController(AuthService authService, Validator validator) {
+        this.authService = authService;
+        this.validator = validator;
+    }
+
+    /**
+     * Registers a new user account.
+     * <p>
+     * Validates the registration request and creates a new user if validation passes.
+     * Returns a JWT response on success or appropriate error responses for failures.
+     * </p>
+     *
+     * @param request the registration request containing user details
+     * @return ResponseEntity containing either:
+     *         <ul>
+     *           <li>JwtResponse on success (200 OK)</li>
+     *           <li>ErrorResponse for validation failures (400 Bad Request)</li>
+     *           <li>ErrorResponse for email conflicts (409 Conflict)</li>
+     *           <li>ErrorResponse for server errors (500 Internal Server Error)</li>
+     *         </ul>
+     * @throws ConstraintViolationException if request validation fails
+     * @see RegisterRequest
+     * @see JwtResponse
+     * @see ErrorResponse
+     */
+    @PostMapping(
+            value = "/register",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ApiResponse<JwtResponse>> register(@RequestBody RegisterRequest request) {
+        Set<ConstraintViolation<RegisterRequest>> violations =
+                validator.validate(request, RegisterRequest.NonOAuthValidation.class);
+
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+
+        try {
+            JwtResponse response = authService.register(request);
+            return ResponseEntity.ok(ApiResponse.success(response, "Registration successful"));
+        } catch (EmailExistException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Registration error", e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("An unexpected error occurred"));
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<JwtResponse>> login(@Valid @RequestBody LoginRequest request) {
+        try {
+            JwtResponse response = authService.login(request);
+            return ResponseEntity.ok(ApiResponse.success(response, "Login successful"));
+        } catch (BadCredentialsException e) {
+            log.warn("Login failed for email: {}", request.email());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error("Invalid email or password"));
+        } catch (Exception e) {
+            log.error("Login error", e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("An unexpected error occurred"));
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout() {
+        return ResponseEntity.ok(ApiResponse.success("Logged out successfully"));
+    }
+
+    @GetMapping("/oauth2/login/success")
+    public ResponseEntity<ApiResponse<Map<String, String>>> loginSuccess(@RequestParam String token) {
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of("token", token),
+                "Login successful"
+        ));
+    }
+
+    @GetMapping("/oauth2/failure")
+    public ResponseEntity<ApiResponse<String>> handleFailure(@RequestParam String error) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("OAuth2 authentication failed: " + error));
+    }
+
+    @GetMapping("/check-roles")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> checkRoles(Authentication authentication) {
+        Map<String, Object> response = Map.of(
+                "username", authentication.getName(),
+                "roles", authentication.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.toList())
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/auth/check-auth")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> checkAuthentication(Authentication authentication) {
+        Map<String, Object> response = Map.of(
+                "name", authentication.getName(),
+                "authorities", authentication.getAuthorities()
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/token-refresh")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> refreshToken() {
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of("expires_in", 3600),
+                "Token refreshed successfully"
+        ));
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/controller/UserController.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/controller/UserController.java
@@ -1,0 +1,97 @@
+package gtp.bytebites.auth.controller;
+
+import gtp.bytebites.auth.dto.response.UserResponse;
+import gtp.bytebites.auth.model.User;
+import gtp.bytebites.auth.service.UserService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for user-related operations and user management.
+ * <p>
+ * Provides endpoints for retrieving user information, with different access levels
+ * based on user roles. Serves as the primary interface for user data retrieval operations.
+ * </p>
+ *
+ * <p><b>Endpoint Structure:</b></p>
+ * <ul>
+ *   <li>Base path: {@code /api/v1/users}</li>
+ *   <li>Personal user data: {@code /me}</li>
+ *   <li>Admin user management: {@code /admin/users}</li>
+ * </ul>
+ *
+ * <p><b>Security:</b></p>
+ * <ul>
+ *   <li>All endpoints require authentication</li>
+ *   <li>Admin-specific endpoints require elevated privileges</li>
+ *   <li>Uses Spring Security's {@code @PreAuthorize} for method-level security</li>
+ * </ul>
+ *
+ * <p><b>Pagination:</b></p>
+ * Admin endpoints support pagination with default page size of 10 items.
+ *
+ * @see UserService
+ * @see UserResponse
+ * @see org.springframework.security.access.prepost.PreAuthorize
+ */
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserService userService;
+
+    /**
+     * Constructs a new UserController with the required service dependency.
+     *
+     * @param userService the user service implementation for business logic operations
+     */
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * Retrieves the currently authenticated user's information.
+     * <p>
+     * Returns a detailed response containing the user's profile data. The information
+     * returned is always specific to the currently logged-in user.
+     * </p>
+     *
+     * @return ResponseEntity containing the user's data wrapped in {@link UserResponse}
+     * @throws org.springframework.security.access.AccessDeniedException if not authenticated
+     * @see UserResponse
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getCurrentUser() {
+        User user = userService.getCurrentUser();
+        return ResponseEntity.ok(new UserResponse(user));
+    }
+
+    /**
+     * Retrieves a paginated list of all users (Admin-only endpoint).
+     * <p>
+     * This endpoint requires ADMIN or MANAGER privileges and returns a paginated
+     * list of all users in the system. The default page size is 10 items,
+     * which can be customized via request parameters.
+     * </p>
+     *
+     * @param pageable the pagination information (page number, size, and sorting)
+     *
+     * @return ResponseEntity containing a page of {@link UserResponse} objects
+     * @throws org.springframework.security.access.AccessDeniedException if not authorized
+     * @see Page
+     * @see Pageable
+     */
+    @GetMapping("/admin/users")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_MANAGER')")
+    public ResponseEntity<Page<UserResponse>> getAllUsers(@PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(userService.getAllUsers(pageable));
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/request/LoginRequest.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/request/LoginRequest.java
@@ -1,0 +1,28 @@
+package gtp.bytebites.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for user login requests.
+ *
+ * @apiNote Used in POST /auth/login endpoint
+ */
+public record LoginRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Invalid email format")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        String password
+) {
+    /**
+     * Returns a sanitized copy with trimmed strings and lowercase email
+     */
+    public LoginRequest sanitized() {
+        return new LoginRequest(
+                email.trim().toLowerCase(),
+                password.trim()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/request/RegisterRequest.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/request/RegisterRequest.java
@@ -1,0 +1,38 @@
+package gtp.bytebites.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for user registration requests.
+ *
+ * @apiNote Used in POST /auth/register endpoint
+ */
+public record RegisterRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Invalid email format")
+        String email,
+
+        @NotBlank(message = "Password is required", groups = NonOAuthValidation.class)
+        @Size(min = 8, max = 64, message = "Password must be 8-64 characters",
+                groups = NonOAuthValidation.class)
+        String password,
+
+        @NotBlank(message = "Name is required")
+        @Size(max = 100, message = "Name must be under 100 characters")
+        String name
+) {
+    public interface NonOAuthValidation {}
+
+    /**
+     * Returns a sanitised copy with trimmed strings and lowercase email
+     */
+    public RegisterRequest sanitized() {
+        return new RegisterRequest(
+                email.trim().toLowerCase(),
+                password != null ? password.trim() : null,
+                name.trim()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/response/ApiResponse.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/response/ApiResponse.java
@@ -1,0 +1,55 @@
+package gtp.bytebites.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ApiResponse<T> {
+    @JsonProperty("success")
+    private boolean success;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("data")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    @JsonProperty("timestamp")
+    private String timestamp;
+
+    @JsonProperty("errors")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<T> errors;
+
+    public ApiResponse(boolean b, String success, T data, String timestamp, List<T> errors) {
+        this.success = b;
+        this.message = success;
+        this.data = data;
+        this.timestamp = timestamp;
+        this.errors = errors;
+
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<T>(true, "Success", data,
+                LocalDateTime.now().toString(), null);
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(true, message, data,
+                LocalDateTime.now().toString(), null);
+    }
+
+    public static <T> ApiResponse<T> error(String message, List<T> errors) {
+        return new ApiResponse<>(false, message, null,
+                LocalDateTime.now().toString(), errors);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null,
+                LocalDateTime.now().toString(), null);
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/response/ErrorResponse.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/response/ErrorResponse.java
@@ -1,0 +1,36 @@
+package gtp.bytebites.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        LocalDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        List<ValidationError> validationErrors,
+        Map<String, Object> details
+) {
+    public record ValidationError(
+            String field,
+            Object rejectedValue,
+            String message
+    ) {}
+
+    public static ErrorResponse of(int status, String error, String message, String path) {
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                status,
+                error,
+                message,
+                path,
+                null,
+                null
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/response/JwtResponse.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/response/JwtResponse.java
@@ -1,0 +1,50 @@
+package gtp.bytebites.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * JWT authentication response containing token and user details
+ *
+ * @param token JWT access token
+ * @param userId Authenticated user's ID
+ * @param email Authenticated user's email
+ * @param role User's assigned role (ADMIN/DEVELOPER/etc.)
+ * @param expiresInMs Milliseconds until token expiration
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "JWT authentication response")
+public record JwtResponse(
+        @Schema(description = "JWT access token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String token,
+
+        @Schema(description = "Authenticated user's ID", example = "123")
+        UUID userId,
+
+        @Schema(description = "Authenticated user's email", example = "user@example.com")
+        String email,
+
+        @Schema(description = "User's assigned role", example = "CUSTOMER")
+        String role,
+
+        @Schema(description = "Milliseconds until token expiration", example = "900000")
+        long expiresInMs
+) {
+    /**
+     * Creates a response with additional calculated fields
+     */
+    public JwtResponse {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("Token cannot be null or blank");
+        }
+    }
+
+    /**
+     * @return Expiration time in seconds (for client convenience)
+     */
+    public long expiresInSec() {
+        return expiresInMs / 1000;
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/response/UserResponse.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/response/UserResponse.java
@@ -1,0 +1,28 @@
+package gtp.bytebites.auth.dto.response;
+
+import gtp.bytebites.auth.model.User;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserResponse(
+        UUID id,
+        String email,
+        String name,
+        User.Role role,
+        boolean isOAuthUser,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public UserResponse(User user) {
+        this(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getRole(),
+                user.isOauth2User(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/dto/response/UserSummaryResponse.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/dto/response/UserSummaryResponse.java
@@ -1,0 +1,22 @@
+package gtp.bytebites.auth.dto.response;
+
+import gtp.bytebites.auth.model.User;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserSummaryResponse(
+        UUID id,
+        String email,
+        String name,
+        User.Role role
+) {
+    public UserSummaryResponse(User user) {
+        this(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getRole()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/exception/EmailExistException.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/exception/EmailExistException.java
@@ -1,0 +1,22 @@
+package gtp.bytebites.auth.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when attempting to register with an email that already exists
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class EmailExistException extends RuntimeException {
+
+    private final String email;
+
+    public EmailExistException(String email) {
+        super(String.format("Email '%s' is already registered", email));
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/mapper/UserMapper.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/mapper/UserMapper.java
@@ -1,0 +1,30 @@
+package gtp.bytebites.auth.mapper;
+
+import gtp.bytebites.auth.dto.request.RegisterRequest;
+import gtp.bytebites.auth.dto.response.UserResponse;
+import gtp.bytebites.auth.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public User toEntity(RegisterRequest request) {
+        return new User(
+                request.name(),
+                request.email(),
+                request.password()
+        );
+    }
+
+    public UserResponse toResponse(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getRole(),
+                user.isOauth2User(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/model/User.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/model/User.java
@@ -36,6 +36,10 @@ public class User {
     private LocalDateTime createdAt = LocalDateTime.now();
     private LocalDateTime updatedAt = LocalDateTime.now();
 
+    public boolean isOauth2User() {
+        return oauth2user;
+    }
+
     public enum Role {
         ROLE_CUSTOMER,
         ROLE_RESTAURANT_OWNER,

--- a/auth-service/src/main/java/gtp/bytebites/auth/security/config/JwtConfig.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/security/config/JwtConfig.java
@@ -1,0 +1,70 @@
+package gtp.bytebites.auth.security.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Configuration class for JWT (JSON Web Token) settings.
+ *
+ * <p>This class binds to properties prefixed with "app.jwt" in the application configuration,
+ * allowing for externalized configuration of JWT parameters.</p>
+ *
+ * <p>Properties configured:</p>
+ * <ul>
+ *   <li><b>secret</b>: The base secret key used for JWT signing and verification</li>
+ *   <li><b>expirationMs</b>: Expiration time for regular access tokens in milliseconds</li>
+ *   <li><b>refreshExpirationMs</b>: Expiration time for refresh tokens in milliseconds</li>
+ * </ul>
+ *
+ * @see ConfigurationProperties
+ * @see Configuration
+ */
+@Configuration
+@ConfigurationProperties(prefix = "app.jwt")
+public class JwtConfig {
+    private String secret;
+    private long expirationMs;
+    private long refreshExpirationMs;
+
+    /**
+     * Gets the JWT secret key as a byte array in Base64 encoded format.
+     * This is the format typically required by JWT signing algorithms.
+     *
+     * @return byte array representation of the Base64 encoded secret key
+     */
+    public byte[] getSecretBytes() {
+        return Base64.getEncoder().encodeToString(secret.getBytes(StandardCharsets.UTF_8)).getBytes();
+    }
+
+    public String getSecret() {
+        if (secret == null || secret.length() < 32) {
+            throw new IllegalStateException(
+                    "JWT secret must be at least 32 characters long. " +
+                            "Current length: " + (secret != null ? secret.length() : "null") + secret);
+        }
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    public void setExpirationMs(long expirationMs) {
+        this.expirationMs = expirationMs;
+    }
+
+    public long getRefreshExpirationMs() {
+        return refreshExpirationMs;
+    }
+
+    public void setRefreshExpirationMs(long refreshExpirationMs) {
+        this.refreshExpirationMs = refreshExpirationMs;
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/security/config/SecurityConfig.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/security/config/SecurityConfig.java
@@ -1,0 +1,135 @@
+package gtp.bytebites.auth.security.config;
+
+import gtp.bytebites.auth.security.jwt.JwtAuthEntryPoint;
+import gtp.bytebites.auth.security.jwt.JwtAuthFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+/**
+ * Main security configuration class for the application.
+ * Configures authentication, authorization, and security filters for both JWT and OAuth2 authentication.
+ *
+ * <p>This class enables web security, method-level security, and configures:</p>
+ * <ul>
+ *   <li>JWT authentication filter</li>
+ *   <li>OAuth2 login flow</li>
+ *   <li>Password encoding</li>
+ *   <li>Authentication manager</li>
+ *   <li>CSRF protection</li>
+ *   <li>CORS configuration</li>
+ *   <li>Session management (stateless)</li>
+ *   <li>Exception handling for authentication failures</li>
+ * </ul>
+ *
+ * @see EnableWebSecurity
+ * @see EnableMethodSecurity
+ * @see SecurityFilterChain
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
+
+    JwtAuthEntryPoint jwtAuthEntryPoint;
+    JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthEntryPoint jwtAuthEntryPoint,  JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthEntryPoint = jwtAuthEntryPoint;
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
+    /**
+     * Configures the security filter chain with HTTP security settings.
+     *
+     * <p>This configuration:</p>
+     * <ul>
+     *   <li>Disables CSRF protection (stateless API)</li>
+     *   <li>Enables CORS with default settings</li>
+     *   <li>Sets up request authorization rules</li>
+     *   <li>Configures OAuth2 login with custom user service and handlers</li>
+     *   <li>Sets exception handling for authentication failures</li>
+     *   <li>Configures stateless session management</li>
+     *   <li>Adds JWT authentication filter</li>
+     * </ul>
+     *
+     * @param http the HttpSecurity to configure
+     * @return the configured SecurityFilterChain
+     * @throws Exception if configuration fails
+     */
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/register",
+                                "/api/v1/auth/**",
+                                "/oauth2/**",
+                                "/login/oauth2/code/**",
+                                "/auth/oauth2/login/**",
+                                "/v3/api-docs.yaml",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/actuator/**",
+                                "/error"
+                        ).permitAll()
+                        .requestMatchers("logs/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/users/me").authenticated()
+                        .requestMatchers("/api/v1/users/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthEntryPoint)
+                )
+                .sessionManagement(sess -> sess
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    /**
+     * Provides a password encoder bean for hashing and verifying passwords.
+     * Uses BCrypt hashing algorithm with default strength.
+     *
+     * @return BCryptPasswordEncoder instance
+     */
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Provides an AuthenticationManager bean configured with the authentication configuration.
+     * The AuthenticationManager is used to authenticate users with their credentials.
+     *
+     * @param config the AuthenticationConfiguration to get the manager from
+     * @return configured AuthenticationManager
+     * @throws Exception if authentication manager cannot be created
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtAuthEntryPoint.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtAuthEntryPoint.java
@@ -1,0 +1,45 @@
+package gtp.bytebites.auth.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gtp.bytebites.auth.dto.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Handles unauthorised access attempts by returning a structured JSON response
+ * instead of the default Spring Security HTML error page.
+ */
+@Component
+public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "Unauthorized",
+                authException.getMessage(),
+                request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtAuthFilter.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtAuthFilter.java
@@ -1,0 +1,95 @@
+package gtp.bytebites.auth.security.jwt;
+
+import gtp.bytebites.auth.service.UserDetailsServiceImpl;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthFilter.class);
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final WebAuthenticationDetailsSource authDetailsSource;
+
+    public JwtAuthFilter(JwtProvider jwtProvider,
+                         UserDetailsServiceImpl userDetailsService) {
+        this.jwtProvider = jwtProvider;
+        this.userDetailsService = userDetailsService;
+        this.authDetailsSource = new WebAuthenticationDetailsSource();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = parseJwt(request);
+            if (jwt == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            if (!jwtProvider.validateToken(jwt)) {
+                sendError(response, "Invalid token");
+                return;
+            }
+
+            String email = jwtProvider.getEmailFromJwt(jwt);
+            if (email == null || email.isEmpty()) {
+                sendError(response, "Missing email in token");
+                return;
+            }
+
+            authenticateUser(request, email);
+        } catch (Exception e) {
+            log.error("Authentication error", e);
+            sendError(response, e.getMessage());
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateUser(HttpServletRequest request, String email) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities());
+
+        authentication.setDetails(authDetailsSource.buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("Authenticated user: {}", email);
+    }
+
+    private String parseJwt(HttpServletRequest request) {
+        String authHeader = request.getHeader(AUTH_HEADER);
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    private void sendError(HttpServletResponse response, String message) throws IOException {
+        log.error(message);
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtProvider.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/security/jwt/JwtProvider.java
@@ -1,0 +1,123 @@
+package gtp.bytebites.auth.security.jwt;
+
+
+import gtp.bytebites.auth.security.config.JwtConfig;
+import gtp.bytebites.auth.service.UserDetailsImpl;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtProvider {
+    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
+
+    private final JwtConfig jwtConfig;
+    private Key signingKey;
+    private JwtParser jwtParser;
+
+    public JwtProvider(JwtConfig jwtConfig) {
+        this.jwtConfig = jwtConfig;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            // Validate secret before use
+            String secret = jwtConfig.getSecret();
+            if (secret == null || secret.trim().isEmpty()) {
+                throw new IllegalStateException("JWT secret is null or empty");
+            }
+
+            // Ensure proper key length
+            byte[] keyBytes = secret.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            if (keyBytes.length < 32) { // 256 bits
+                throw new IllegalStateException("JWT secret must be at least 256 bits (32 characters)");
+            }
+
+            this.signingKey = Keys.hmacShaKeyFor(keyBytes);
+            this.jwtParser = Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build();
+
+            log.info("JwtProvider initialized successfully");
+        } catch (Exception e) {
+            log.error("Failed to initialize JwtProvider", e);
+            throw new IllegalStateException("JWT initialization failed", e);
+        }
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        UserDetailsImpl user = (UserDetailsImpl) userDetails;
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", user.getUsername());
+        claims.put("roles", userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList()));
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(user.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtConfig.getExpirationMs()))
+                .signWith(signingKey, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            jwtParser.parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public long getExpirationDuration() {
+        return jwtConfig.getExpirationMs();
+    }
+
+    public String getUsernameFromJwt(String jwt) {
+        return getClaimFromJwt(jwt, Claims::getSubject);
+    }
+
+    public String getEmailFromJwt(String jwt) {
+        return getClaimFromJwt(jwt, Claims::getSubject);
+    }
+
+    public String getClaimFromJwt(String jwt, String claimName) {
+        return getClaimFromJwt(jwt, claims -> claims.get(claimName, String.class));
+    }
+
+    public Date getExpirationDateFromJwt(String jwt) {
+        return getClaimFromJwt(jwt, Claims::getExpiration);
+    }
+
+    private <T> T getClaimFromJwt(String jwt, ClaimsResolver<T> resolver) {
+        try {
+            Claims claims = jwtParser.parseClaimsJws(jwt).getBody();
+            return resolver.resolve(claims);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Error extracting claim from JWT: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @FunctionalInterface
+    private interface ClaimsResolver<T> {
+        T resolve(Claims claims);
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/service/AuthService.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package gtp.bytebites.auth.service;
+
+import gtp.bytebites.auth.dto.request.LoginRequest;
+import gtp.bytebites.auth.dto.request.RegisterRequest;
+import gtp.bytebites.auth.dto.response.JwtResponse;
+
+public interface AuthService {
+    JwtResponse register(RegisterRequest request);
+    JwtResponse login(LoginRequest request);
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/service/AuthServiceImpl.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/service/AuthServiceImpl.java
@@ -1,0 +1,111 @@
+package gtp.bytebites.auth.service;
+
+import gtp.bytebites.auth.dto.request.LoginRequest;
+import gtp.bytebites.auth.dto.request.RegisterRequest;
+import gtp.bytebites.auth.dto.response.JwtResponse;
+import gtp.bytebites.auth.model.User;
+import gtp.bytebites.auth.model.User.Role;
+import gtp.bytebites.auth.repository.UserRepository;
+import gtp.bytebites.auth.security.jwt.JwtProvider;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+    private static final Logger log = LoggerFactory.getLogger(AuthServiceImpl.class);
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final Validator validator;
+
+    public AuthServiceImpl(
+            AuthenticationManager authenticationManager,
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtProvider jwtProvider,
+            Validator validator
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.validator = validator;
+    }
+
+    @Override
+    @Transactional
+    public JwtResponse register(RegisterRequest request) {
+        RegisterRequest sanitised = request.sanitized();
+        Set<ConstraintViolation<RegisterRequest>> violations =
+                validator.validate(request, RegisterRequest.NonOAuthValidation.class);
+
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+
+        if (userRepository.existsByEmail(sanitised.email())) {
+            throw new IllegalArgumentException("Email already exists: " + sanitised.email());
+        }
+
+        User user = new User();
+        user.setEmail(sanitised.email());
+        user.setPassword(passwordEncoder.encode(sanitised.password()));
+        user.setName(sanitised.name());
+        user.setRole(determineDefaultRole());
+
+        User savedUser = userRepository.save(user);
+        UserDetailsImpl userDetails = new UserDetailsImpl(savedUser);
+        return generateTokenResponse(userDetails);
+    }
+
+    @Override
+    public JwtResponse login(LoginRequest request) {
+        try {
+            LoginRequest sanitised = request.sanitized();
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            sanitised.email(),
+                            sanitised.password()
+                    )
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+            return generateTokenResponse(userDetails);
+        } catch (BadCredentialsException ex) {
+            throw ex;
+        }
+    }
+
+    private Role determineDefaultRole() {
+        return userRepository.count() == 0 ? Role.ROLE_ADMIN : Role.ROLE_CUSTOMER;
+    }
+
+    private JwtResponse generateTokenResponse(UserDetailsImpl user) {
+        String jwt = jwtProvider.generateToken(user);
+        return new JwtResponse(
+                jwt,
+                user.getUser().getId(),
+                user.getUser().getEmail(),
+                user.getUser().getRole().name(),
+                jwtProvider.getExpirationDuration()
+        );
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/service/UserDetailsImpl.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/service/UserDetailsImpl.java
@@ -1,0 +1,71 @@
+package gtp.bytebites.auth.service;
+
+import gtp.bytebites.auth.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(this.user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    public boolean isOauth2User() {
+        return user.isOauth2User();
+    }
+
+    public UUID getId() {
+        return user.getId();
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/service/UserDetailsServiceImpl.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package gtp.bytebites.auth.service;
+
+import gtp.bytebites.auth.model.User;
+import gtp.bytebites.auth.repository.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Cacheable(value = "users", key = "#email")
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/auth-service/src/main/java/gtp/bytebites/auth/service/UserService.java
+++ b/auth-service/src/main/java/gtp/bytebites/auth/service/UserService.java
@@ -1,0 +1,47 @@
+package gtp.bytebites.auth.service;
+
+import gtp.bytebites.auth.dto.response.UserResponse;
+import gtp.bytebites.auth.mapper.UserMapper;
+import gtp.bytebites.auth.model.User;
+import gtp.bytebites.auth.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Autowired
+    public UserService(UserRepository userRepository,   UserMapper userMapper) {
+        this.userRepository = userRepository;
+        this.userMapper = userMapper;
+    }
+
+    @Cacheable("users")
+    public User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    public Page<UserResponse> getAllUsers(Pageable pageable) {
+        return userRepository.findAll(pageable)
+                .map(userMapper::toResponse);
+    }
+
+    public Optional<User> getUserById(UUID id) {
+        return userRepository.findById(id);
+    }
+
+    public boolean existsById(UUID userId) {
+        return userRepository.existsById(userId);
+    }
+}

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -7,3 +7,11 @@ spring.cloud.config.name=auth-service
 management.endpoints.web.exposure.include=health,info,prometheus,metrics,caches,threaddump
 management.endpoint.health.show-details=always
 management.prometheus.metrics.export.enabled=true
+
+# jwt config
+app.jwt.secret=${JWT_SECRET}
+app.jwt.expiration-ms=900000
+app.jwt.refresh-expiration-ms=604800000
+
+logging.level.org.springframework.security=TRACE
+logging.level.org.springframework.web=DEBUG

--- a/auth-service/src/main/resources/bootstrap.properties
+++ b/auth-service/src/main/resources/bootstrap.properties
@@ -5,9 +5,7 @@ spring.cloud.config.fail-fast=true
 spring.cloud.config.retry.initial-interval=1000
 spring.cloud.config.retry.max-interval=2000
 spring.cloud.config.retry.max-attempts=3
-spring.cloud.config.enabled=true:w
-
-
+spring.cloud.config.enabled=true
 
 
 # Eureka Client Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # docker-compose.yml (root level)
 
 services:
-  # Shared Databases
   postgres:
     container_name: postgres-bb
     image: postgres:latest

--- a/infrastructure/api-gateway/pom.xml
+++ b/infrastructure/api-gateway/pom.xml
@@ -37,6 +37,24 @@
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
 
+         <!--Security-->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
         <!-- JJWT Library (token generation/parsing) -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/config/GatewaySecurityConfig.java
+++ b/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/config/GatewaySecurityConfig.java
@@ -1,0 +1,49 @@
+package gtp.bytebites.gateway.config;
+
+import io.jsonwebtoken.security.Keys;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class GatewaySecurityConfig {
+
+    private final JwtGatewayConfig jwtConfig;
+
+    public GatewaySecurityConfig(JwtGatewayConfig jwtConfig) {
+        this.jwtConfig = jwtConfig;
+    }
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf().disable()
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers(
+                                "/api/v1/auth/**",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/actuator/**",
+                                "/error"
+                        ).permitAll()
+                        .anyExchange().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtDecoder(this.jwtDecoder()))
+                )
+                .build();
+    }
+
+    @Bean
+    public ReactiveJwtDecoder jwtDecoder() {
+        return NimbusReactiveJwtDecoder.withSecretKey(
+                Keys.hmacShaKeyFor(jwtConfig.getSecretBytes())
+        ).build();
+    }
+}

--- a/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/config/JwtGatewayConfig.java
+++ b/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/config/JwtGatewayConfig.java
@@ -1,0 +1,39 @@
+package gtp.bytebites.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Configuration
+@ConfigurationProperties(prefix = "app.jwt")
+public class JwtGatewayConfig {
+    private String secret;
+    private long expirationMs;
+
+    public String getSecret() {
+        if (secret == null || secret.length() < 32) {
+            throw new IllegalStateException(
+                    "JWT secret must be at least 32 characters long. Current length: " +
+                            (secret != null ? secret.length() : "null"));
+        }
+        return secret;
+    }
+
+    public byte[] getSecretBytes() {
+        return Base64.getEncoder().encodeToString(secret.getBytes(StandardCharsets.UTF_8)).getBytes();
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    public void setExpirationMs(long expirationMs) {
+        this.expirationMs = expirationMs;
+    }
+}

--- a/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/filters/JwtGlobalFilter.java
+++ b/infrastructure/api-gateway/src/main/java/gtp/bytebites/gateway/filters/JwtGlobalFilter.java
@@ -1,0 +1,81 @@
+package gtp.bytebites.gateway.filters;
+
+import io.jsonwebtoken.JwtException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class JwtGlobalFilter implements GlobalFilter, Ordered {
+
+    private final ReactiveJwtDecoder jwtDecoder;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Value("${app.security.whitelist}")
+    private String whitelistPaths;
+
+    public JwtGlobalFilter(ReactiveJwtDecoder jwtDecoder) {
+        this.jwtDecoder = jwtDecoder;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getPath().toString();
+
+        if (isWhitelisted(path)) {
+            return chain.filter(exchange);
+        }
+
+        return Mono.justOrEmpty(exchange.getRequest().getHeaders().getFirst("Authorization"))
+                .switchIfEmpty(Mono.error(new JwtException("Missing Authorization header")))
+                .flatMap(authHeader -> {
+                    if (!authHeader.startsWith("Bearer ")) {
+                        return Mono.error(new JwtException("Invalid Authorization header"));
+                    }
+
+                    String token = authHeader.substring(7);
+                    return jwtDecoder.decode(token)
+                            .doOnSuccess(jwt -> {
+                                exchange.getRequest().mutate()
+                                        .header("X-User-Id", jwt.getSubject())
+                                        .header("X-User-Roles", String.join(",", jwt.getClaimAsStringList("roles")))
+                                        .build();
+                            });
+                })
+                .then(chain.filter(exchange))
+                .onErrorResume(JwtException.class, e -> {
+                    exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                    return exchange.getResponse().setComplete();
+                })
+                .onErrorResume(Exception.class, e -> {
+                    exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                    return exchange.getResponse().setComplete();
+                });
+    }
+
+    private boolean isWhitelisted(String path) {
+        if (whitelistPaths == null || whitelistPaths.trim().isEmpty()) {
+            return false;
+        }
+
+        List<String> patterns = Arrays.asList(whitelistPaths.split(","));
+        return patterns.stream()
+                .map(String::trim)
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+}

--- a/infrastructure/api-gateway/src/main/resources/application.properties
+++ b/infrastructure/api-gateway/src/main/resources/application.properties
@@ -7,19 +7,25 @@ spring.config.import=configserver:http://localhost:8085
 eureka.client.service-url.defaultZone=http://localhost:8086/eureka
 eureka.instance.prefer-ip-address=true
 
-# jwt config
-app.jwt.secret=${JWT_SECRET}
-app.jwt.expiration-ms=900000
-app.jwt.refresh-expiration-ms=604800000
-
 # Enable WebFlux for Spring Cloud Gateway
 spring.cloud.gateway.server.webflux.enabled=true
+
+app.jwt.secret=${JWT_SECRET}
+app.jwt.expiration-ms=86400000
+
+app.security.whitelist=/api/v1/auth/**,/oauth2/**,/error,/v3/api-docs/**,/swagger-ui/**,/actuator/**
+
+# Global CORS
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-origins=*
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-headers=Content-Type,Authorization,X-Requested-With,X-User-Id,X-User-Roles
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].max-age=3600
 
 # Auth Service Route
 spring.cloud.gateway.server.webflux.routes[0].id=auth-service
 spring.cloud.gateway.server.webflux.routes[0].uri=lb://auth-service
 spring.cloud.gateway.server.webflux.routes[0].predicates[0]=Path=/api/v1/auth/**
-#spring.cloud.gateway.server.webflux.routes[0].filters[0]=JwtAuthFilter=false
+#spring.cloud.gateway.server.webflux.routes[0].filters[0]=JwtAuthFilter=true
 
 # Restaurant Service Route
 spring.cloud.gateway.server.webflux.routes[1].id=restaurant-service
@@ -39,15 +45,14 @@ spring.cloud.gateway.server.webflux.routes[3].uri=lb://notification-service
 spring.cloud.gateway.server.webflux.routes[3].predicates[0]=Path=/api/v1/notifications/**
 #spring.cloud.gateway.server.webflux.routes[3].filters[0]=JwtAuthFilter=true
 
-## Global Filters
+# Global Filters
 #spring.cloud.gateway.server.webflux.default-filters[0]=JwtAuthFilter
 #spring.cloud.gateway.server.webflux.default-filters[1]=RateLimitingFilter
-#
-## CORS Configuration
-#spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-origins=*
-#spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-#spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-headers=Content-Type,Authorization,X-Requested-With
-#spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].max-age=3600
+
+# Global Filters (order matters!)
+spring.cloud.gateway.server.webflux.default-filters[0]=RemoveRequestHeader=X-User-Id
+spring.cloud.gateway.server.webflux.default-filters[1]=RemoveRequestHeader=X-User-Roles
+
 
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,12 @@
         <module>infrastructure/discovery-server</module>
         <module>infrastructure/config-server</module>
         <module>infrastructure/api-gateway</module>
+
         <module>auth-service</module>
         <module>business-services/restaurant-service</module>
         <module>business-services/order-service</module>
         <module>notification-service</module>
+
         <module>shared-libs/common-events</module>
         <module>shared-libs/common-security</module>
         <module>shared-libs/common-audit</module>
@@ -56,11 +58,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-amqp</artifactId>
                 <version>3.5.3</version>
-            </dependency>
-            <dependency>
-                <groupId>me.paulschwarz</groupId>
-                <artifactId>spring-dotenv</artifactId>
-                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/shared-libs/common-audit/pom.xml
+++ b/shared-libs/common-audit/pom.xml
@@ -18,5 +18,12 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+    </dependencies>
     
 </project>

--- a/shared-libs/common-audit/src/main/java/gtp/bytebites/audit/config/MongoConfig.java
+++ b/shared-libs/common-audit/src/main/java/gtp/bytebites/audit/config/MongoConfig.java
@@ -1,8 +1,7 @@
-package gtp.bytebites.auth.config;
+package gtp.bytebites.audit.config;
 
+import gtp.bytebites.audit.model.AuditLog;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -13,7 +12,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 /**
  * Configuration class for MongoDB-specific settings.
  * Sets up indexes and other MongoDB configurations required by the application.
- * Currently, configures a TTL (time-to-live) index on audit logs to automatically
+ * Currently configures a TTL (time-to-live) index on audit logs to automatically
  * delete old entries after a specified period.
  */
 @Configuration

--- a/shared-libs/common-audit/src/main/java/gtp/bytebites/audit/model/AuditLog.java
+++ b/shared-libs/common-audit/src/main/java/gtp/bytebites/audit/model/AuditLog.java
@@ -1,0 +1,208 @@
+package gtp.bytebites.audit.model;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+/**
+ * Document class representing an audit log entry in the project tracking system.
+ *
+ * An audit log records actions performed on entities within the system, such as
+ * creation, updates, and deletions. Each log entry includes information about the
+ * action type, the entity affected, when the action occurred, who performed it,
+ * and additional payload data related to the action.
+ *
+ * This class is stored in MongoDB rather than a relational database to allow for
+ * flexible schema and efficient storage of high-volume audit data.
+ */
+@Document(collection = "audit_logs")
+public class AuditLog {
+    @Id
+    private ObjectId id;
+
+    private ActionType actionType;
+    private String entityType;
+    private String entityId;
+    private Instant timestamp = Instant.now();
+    private String actorName;
+    private String payload;
+
+    // Security-specific fields
+    private String ipAddress;
+    private String userAgent;
+    private String endpoint;
+
+    /**
+     * Enumeration of possible audit action types.
+     * These types represent the different kinds of actions that can be audited.
+     */
+    public enum ActionType {
+        CREATE,
+        UPDATE,
+        DELETE,
+        LOGIN_SUCCESS,
+        LOGIN_FAILURE,
+        LOGOUT,
+        ACCESS_DENIED,
+        REGISTRATION_SUCCESS,
+        REGISTRATION_FAILURE,
+        INVALID_TOKEN
+    }
+
+    /**
+     * Gets the unique identifier of the audit log entry.
+     *
+     * @return The audit log's unique identifier
+     */
+    public ObjectId getId() {
+        return id;
+    }
+
+    /**
+     * Sets the unique identifier of the audit log entry.
+     * This method is typically used by MongoDB and not in application code.
+     *
+     * @param id The unique identifier to set
+     */
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the type of action recorded in this audit log entry.
+     *
+     * @return The action type
+     * @see ActionType
+     */
+    public ActionType getActionType() {
+        return actionType;
+    }
+
+    /**
+     * Sets the type of action for this audit log entry.
+     *
+     * @param actionType The action type to set
+     * @see ActionType
+     */
+    public void setActionType(ActionType actionType) {
+        this.actionType = actionType;
+    }
+
+    /**
+     * Gets the type of entity that was affected by the audited action.
+     * This is typically the class name of the entity.
+     *
+     * @return The entity type
+     */
+    public String getEntityType() {
+        return entityType;
+    }
+
+    /**
+     * Sets the type of entity that was affected by the audited action.
+     *
+     * @param entityType The entity type to set
+     */
+    public void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+    /**
+     * Gets the identifier of the specific entity that was affected by the audited action.
+     *
+     * @return The entity identifier
+     */
+    public String getEntityId() {
+        return entityId;
+    }
+
+    /**
+     * Sets the identifier of the specific entity that was affected by the audited action.
+     *
+     * @param entityId The entity identifier to set
+     */
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
+    }
+
+    /**
+     * Gets the timestamp when the audited action occurred.
+     *
+     * @return The timestamp of the action
+     */
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the timestamp when the audited action occurred.
+     *
+     * @param now The timestamp to set
+     */
+    public void setTimestamp(Instant now) {
+        this.timestamp = now;
+    }
+
+    /**
+     * Gets the name of the actor (user or system) that performed the audited action.
+     *
+     * @return The actor's name
+     */
+    public String getActorName() {
+        return actorName;
+    }
+
+    /**
+     * Sets the name of the actor that performed the audited action.
+     *
+     * @param actorName The actor's name to set
+     */
+    public void setActorName(String actorName) {
+        this.actorName = actorName;
+    }
+
+    /**
+     * Gets the additional payload data associated with the audited action.
+     * This typically contains details about the changes made to the entity.
+     *
+     * @return The payload data
+     */
+    public String getPayload() {
+        return payload;
+    }
+
+    /**
+     * Sets the additional payload data associated with the audited action.
+     *
+     * @param payload The payload data to set
+     */
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/shared-libs/common-audit/src/main/resources/application.properties
+++ b/shared-libs/common-audit/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-spring.application.name=common-audits
+spring.application.name=common-audit
+
+


### PR DESCRIPTION
- Added JWT generation/validation in auth-service with:
  * JwtProvider for token creation and parsing
  * JwtAuthFilter for request authentication
  * SecurityConfig with role-based access control
- Implemented API Gateway security layer:
  * JwtGlobalFilter for centralised token validation
  * Role propagation via X-User-Roles headers
  * Whitelisted auth endpoints (/api/v1/auth/**)
- Configured shared JWT properties across services:
  * Base64-encoded 256-bit secret
  * 24-hour token expiration
- Established service routing in gateway:
  * Auth-service route (/api/v1/auth)
  * Downstream service routes (/api/v1/orders, etc.)

BREAKING CHANGE: All services now require valid JWT from gateway except whitelisted auth endpoints. Services must implement @PreAuthorize checks using X-User-Roles headers.

Refs: #4 (JWT validation ticket)
Closes: #4
Closes: #5